### PR TITLE
Failover retry writes

### DIFF
--- a/lib/Doctrine/MongoDB/Configuration.php
+++ b/lib/Doctrine/MongoDB/Configuration.php
@@ -28,24 +28,37 @@ namespace Doctrine\MongoDB;
 class Configuration
 {
     /**
-     * Array of attributes for this configuration instance.
-     *
-     * @var array
+     * @deprecated
+     * @var string
      */
-    protected $attributes = [
-        'mongoCmd' => '$',
-        'retryConnect' => 0,
-        'retryQuery' => 0,
-    ];
+    protected $mongoCmd = '$';
+
+    /** @var int */
+    protected $numRetryConnect = 0;
+
+    /** @var int */
+    protected $numRetryReads = 0;
+
+    /** @var int */
+    protected $timeBetweenReadRetriesMs = 0;
+
+    /** @var int */
+    protected $numRetryWrites = 0;
+
+    /** @var int */
+    protected $timeBetweenWriteRetriesMs = 0;
+
+    /** @var callable */
+    protected $loggerCallable;
 
     /**
      * Gets the logger callable.
      *
-     * @return callable
+     * @return callable|null
      */
     public function getLoggerCallable()
     {
-        return isset($this->attributes['loggerCallable']) ? $this->attributes['loggerCallable'] : null;
+        return $this->loggerCallable;
     }
 
     /**
@@ -55,7 +68,7 @@ class Configuration
      */
     public function setLoggerCallable($loggerCallable)
     {
-        $this->attributes['loggerCallable'] = $loggerCallable;
+        $this->loggerCallable = $loggerCallable;
     }
 
     /**
@@ -67,7 +80,7 @@ class Configuration
     public function getMongoCmd()
     {
         trigger_error('MongoDB command prefix option is no longer used', E_USER_DEPRECATED);
-        return $this->attributes['mongoCmd'];
+        return $this->mongoCmd;
     }
 
     /**
@@ -79,7 +92,7 @@ class Configuration
     public function setMongoCmd($cmd)
     {
         trigger_error('MongoDB command prefix option is no longer used', E_USER_DEPRECATED);
-        $this->attributes['mongoCmd'] = $cmd;
+        $this->mongoCmd = $cmd;
     }
 
     /**
@@ -87,38 +100,90 @@ class Configuration
      *
      * @return integer
      */
-    public function getRetryConnect()
+    public function getNumRetryConnect()
     {
-        return $this->attributes['retryConnect'];
+        return $this->numRetryConnect;
     }
 
     /**
      * Set the number of times to retry connection attempts after an exception.
      *
-     * @param boolean|integer $retryConnect
+     * @param boolean|integer $numRetryConnect
      */
-    public function setRetryConnect($retryConnect)
+    public function setNumRetryConnect($numRetryConnect)
     {
-        $this->attributes['retryConnect'] = (integer) $retryConnect;
+        $this->numRetryConnect = (integer) $numRetryConnect;
     }
 
     /**
-     * Get the number of times to retry queries after an exception.
+     * Get the number of times to retry read queries after an exception.
      *
      * @return integer
      */
-    public function getRetryQuery()
+    public function getNumRetryReads()
     {
-        return $this->attributes['retryQuery'];
+        return $this->numRetryReads;
     }
 
     /**
-     * Set the number of times to retry queries after an exception.
+     * Set the number of times to retry read queries after an exception.
      *
-     * @param boolean|integer $retryQuery
+     * @param boolean|integer $numRetryReads
      */
-    public function setRetryQuery($retryQuery)
+    public function setNumRetryReads($numRetryReads)
     {
-        $this->attributes['retryQuery'] = (integer) $retryQuery;
+        $this->numRetryReads = (integer) $numRetryReads;
+    }
+
+    /**
+     * @return int
+     */
+    public function getTimeBetweenReadRetriesMs()
+    {
+        return $this->timeBetweenReadRetriesMs;
+    }
+
+    /**
+     * @param int $timeBetweenReadRetriesMs
+     */
+    public function setTimeBetweenReadRetriesMs($timeBetweenReadRetriesMs)
+    {
+        $this->timeBetweenReadRetriesMs = (integer) $timeBetweenReadRetriesMs;
+    }
+
+    /**
+     * Get the number of times to retry write queries after an exception.
+     *
+     * @return int
+     */
+    public function getNumRetryWrites()
+    {
+        return $this->numRetryWrites;
+    }
+
+    /**
+     * Get the number of times to retry write queries after an exception.
+     *
+     * @param boolean|integer $numRetryWrites
+     */
+    public function setNumRetryWrites($numRetryWrites)
+    {
+        $this->numRetryWrites = (integer) $numRetryWrites;
+    }
+
+    /**
+     * @return int
+     */
+    public function getTimeBetweenWriteRetriesMs()
+    {
+        return $this->timeBetweenWriteRetriesMs;
+    }
+
+    /**
+     * @param int $timeBetweenWriteRetriesMs
+     */
+    public function setTimeBetweenWriteRetriesMs($timeBetweenWriteRetriesMs)
+    {
+        $this->timeBetweenWriteRetriesMs = (integer) $timeBetweenWriteRetriesMs;
     }
 }

--- a/lib/Doctrine/MongoDB/Connection.php
+++ b/lib/Doctrine/MongoDB/Connection.php
@@ -419,12 +419,22 @@ class Connection
     protected function doSelectDatabase($name)
     {
         $mongoDB = $this->mongoClient->selectDB($name);
-        $numRetries = $this->config->getNumRetryReads();
         $loggerCallable = $this->config->getLoggerCallable();
 
         return $loggerCallable !== null
-            ? new LoggableDatabase($this, $mongoDB, $this->eventManager, $numRetries, $loggerCallable)
-            : new Database($this, $mongoDB, $this->eventManager, $numRetries);
+            ? new LoggableDatabase(
+                $this,
+                $mongoDB,
+                $this->eventManager,
+                $this->config,
+                $loggerCallable
+            )
+            : new Database(
+                $this,
+                $mongoDB,
+                $this->eventManager,
+                $this->config
+            );
     }
 
     /**

--- a/lib/Doctrine/MongoDB/Database.php
+++ b/lib/Doctrine/MongoDB/Database.php
@@ -570,7 +570,7 @@ class Database
     {
         $mongoCollection = $this->mongoDB->selectCollection($name);
 
-        return new Collection($this, $mongoCollection, $this->eventManager, $this->numRetries);
+        return new Collection($this, $mongoCollection, $this->eventManager, $this->configuration);
     }
 
     /**

--- a/lib/Doctrine/MongoDB/Database.php
+++ b/lib/Doctrine/MongoDB/Database.php
@@ -23,6 +23,7 @@ use Doctrine\Common\EventManager;
 use Doctrine\MongoDB\Event\CreateCollectionEventArgs;
 use Doctrine\MongoDB\Event\EventArgs;
 use Doctrine\MongoDB\Event\MutableEventArgs;
+use Doctrine\MongoDB\Traits\MillisecondSleepTrait;
 
 /**
  * Wrapper for the MongoDB class.
@@ -35,6 +36,8 @@ use Doctrine\MongoDB\Event\MutableEventArgs;
  */
 class Database
 {
+    use MillisecondSleepTrait;
+
     /**
      * The Connection instance to which this database belongs.
      *
@@ -57,26 +60,28 @@ class Database
     protected $mongoDB;
 
     /**
-     * Number of times to retry queries.
-     *
-     * @var integer
+     * @var Configuration
      */
-    protected $numRetries;
+    protected $configuration;
 
     /**
      * Constructor.
      *
-     * @param Connection      $connection Connection to which this database belongs
-     * @param \MongoDB        $mongoDB    MongoDB instance being wrapped
-     * @param EventManager    $evm        EventManager instance
-     * @param boolean|integer $numRetries Number of times to retry queries
+     * @param Connection      $connection           Connection to which this database belongs
+     * @param \MongoDB        $mongoDB              MongoDB instance being wrapped
+     * @param EventManager    $evm                  EventManager instance
+     * @param Configuration   $configuration
      */
-    public function __construct(Connection $connection, \MongoDB $mongoDB, EventManager $evm, $numRetries = 0)
-    {
+    public function __construct(
+        Connection $connection,
+        \MongoDB $mongoDB,
+        EventManager $evm,
+        Configuration $configuration
+    ) {
         $this->connection = $connection;
         $this->mongoDB = $mongoDB;
         $this->eventManager = $evm;
-        $this->numRetries = (integer) $numRetries;
+        $this->configuration = $configuration;
     }
 
     /**
@@ -418,7 +423,7 @@ class Database
      * Wrapper method for MongoDB::listCollections().
      *
      * @see http://php.net/manual/en/mongodb.listcollections.php
-     * @return array
+     * @return Collection[]
      */
     public function listCollections()
     {
@@ -520,7 +525,7 @@ class Database
     protected function doGetDBRef(array $reference)
     {
         $mongoDB = $this->mongoDB;
-        return $this->retry(function() use ($mongoDB, $reference) {
+        return $this->retryRead(function() use ($mongoDB, $reference) {
             return $mongoDB->getDBRef($reference);
         });
     }
@@ -551,7 +556,7 @@ class Database
     {
         $mongoGridFS = $this->mongoDB->getGridFS($prefix);
 
-        return new GridFS($this, $mongoGridFS, $this->eventManager);
+        return new GridFS($this, $mongoGridFS, $this->eventManager, $this->configuration);
     }
 
     /**
@@ -569,36 +574,34 @@ class Database
     }
 
     /**
-     * Conditionally retry a closure if it yields an exception.
-     *
-     * If the closure does not return successfully within the configured number
-     * of retries, its first exception will be thrown.
-     *
-     * This method should not be used for write operations.
-     *
      * @param \Closure $retry
      * @return mixed
+     * @throws
      */
-    protected function retry(\Closure $retry)
+    protected function retryRead(\Closure $retry)
     {
-        if ($this->numRetries < 1) {
+        $num_retries = $this->configuration->getNumRetryReads();
+        $retry_interval = $this->configuration->getTimeBetweenReadRetriesMs();
+
+        if ($num_retries < 1) {
             return $retry();
         }
 
         $firstException = null;
 
-        for ($i = 0; $i <= $this->numRetries; $i++) {
+        for ($i = 0; $i <= $num_retries; $i++) {
             try {
                 return $retry();
-            } catch (\MongoException $e) {
-                if ($firstException === null) {
-                    $firstException = $e;
-                }
-                if ($i === $this->numRetries) {
-                    throw $firstException;
-                }
+            } catch (\MongoException $exception) {}
+
+            if (!$firstException) {
+                $firstException = $exception;
             }
+
+            $this->sleepForMs($retry_interval);
         }
+
+        throw $firstException;
     }
 
     /**

--- a/lib/Doctrine/MongoDB/GridFS.php
+++ b/lib/Doctrine/MongoDB/GridFS.php
@@ -42,14 +42,18 @@ class GridFS extends Collection
     /**
      * Constructor.
      *
-     * @param Database     $database    Database to which this collection belongs
+     * @param Database $database Database to which this collection belongs
      * @param \MongoGridFS $mongoGridFS MongoGridFS instance being wrapped
-     * @param EventManager $evm         EventManager instance
-     * @param integer      $numRetries  Number of times to retry queries
+     * @param EventManager $evm EventManager instance
+     * @param Configuration $configuration
      */
-    public function __construct(Database $database, \MongoGridFS $mongoGridFS, EventManager $evm, $numRetries = 0)
-    {
-        parent::__construct($database, $mongoGridFS, $evm, $numRetries);
+    public function __construct(
+        Database $database,
+        \MongoGridFS $mongoGridFS,
+        EventManager $evm,
+        Configuration $configuration
+    ) {
+        parent::__construct($database, $mongoGridFS, $evm, $configuration);
     }
 
     /**
@@ -149,7 +153,7 @@ class GridFS extends Collection
     protected function doFindOne(array $query = [], array $fields = [])
     {
         $mongoCollection = $this->mongoCollection;
-        $file = $this->retry(function() use ($mongoCollection, $query, $fields) {
+        $file = $this->retryRead(function() use ($mongoCollection, $query, $fields) {
             return $mongoCollection->findOne($query, $fields);
         });
         if ($file) {

--- a/lib/Doctrine/MongoDB/LoggableCollection.php
+++ b/lib/Doctrine/MongoDB/LoggableCollection.php
@@ -39,16 +39,21 @@ class LoggableCollection extends Collection implements Loggable
      * @param Database         $database        Database to which this collection belongs
      * @param \MongoCollection $mongoCollection MongoCollection instance being wrapped
      * @param EventManager     $evm             EventManager instance
-     * @param integer          $numRetries      Number of times to retry queries
+     * @param Configuration    $configuration
      * @param callable         $loggerCallable  The logger callable
      */
-    public function __construct(Database $database, \MongoCollection $mongoCollection, EventManager $evm, $numRetries, $loggerCallable)
-    {
+    public function __construct(
+        Database $database,
+        \MongoCollection $mongoCollection,
+        EventManager $evm,
+        Configuration $configuration,
+        $loggerCallable
+    ) {
         if ( ! is_callable($loggerCallable)) {
             throw new \InvalidArgumentException('$loggerCallable must be a valid callback');
         }
         $this->loggerCallable = $loggerCallable;
-        parent::__construct($database, $mongoCollection, $evm, $numRetries);
+        parent::__construct($database, $mongoCollection, $evm, $configuration);
     }
 
     /**
@@ -62,6 +67,6 @@ class LoggableCollection extends Collection implements Loggable
      */
     protected function wrapCursor(\MongoCursor $cursor, $query, $fields)
     {
-        return new LoggableCursor($this, $cursor, $query, $fields, $this->numRetries, $this->loggerCallable);
+        return new LoggableCursor($this, $cursor, $this->configuration, $query, $fields, $this->loggerCallable);
     }
 }

--- a/lib/Doctrine/MongoDB/LoggableCursor.php
+++ b/lib/Doctrine/MongoDB/LoggableCursor.php
@@ -39,18 +39,24 @@ class LoggableCursor extends Cursor implements Loggable
      *
      * @param Collection   $collection     Collection used to create this Cursor
      * @param \MongoCursor $mongoCursor    MongoCursor being wrapped
+     * @param Configuration $configuration
      * @param array        $query          Query criteria
      * @param array        $fields         Selected fields (projection)
-     * @param integer      $numRetries     Number of times to retry queries
      * @param callable     $loggerCallable Logger callable
      */
-    public function __construct(Collection $collection, \MongoCursor $mongoCursor, array $query, array $fields, $numRetries, $loggerCallable)
-    {
+    public function __construct(
+        Collection $collection,
+        \MongoCursor $mongoCursor,
+        Configuration $configuration,
+        array $query,
+        array $fields,
+        $loggerCallable
+    ) {
         if ( ! is_callable($loggerCallable)) {
             throw new \InvalidArgumentException('$loggerCallable must be a valid callback');
         }
         $this->loggerCallable = $loggerCallable;
-        parent::__construct($collection, $mongoCursor, $query, $fields, $numRetries);
+        parent::__construct($collection, $mongoCursor, $configuration, $query, $fields);
     }
 
     /**

--- a/lib/Doctrine/MongoDB/LoggableDatabase.php
+++ b/lib/Doctrine/MongoDB/LoggableDatabase.php
@@ -40,18 +40,24 @@ class LoggableDatabase extends Database implements Loggable
     /**
      * Constructor.
      *
-     * @param Connection   $connection     Connection used to create Collections
-     * @param \MongoDB     $mongoDB        MongoDB instance being wrapped
-     * @param EventManager $evm            EventManager instance
-     * @param integer      $numRetries     Number of times to retry queries
-     * @param callable     $loggerCallable The logger callable
+     * @param Connection    $connection              Connection used to create Collections
+     * @param \MongoDB      $mongoDB                 MongoDB instance being wrapped
+     * @param EventManager  $evm                     EventManager instance
+     * @param Configuration $configuration
+     * @param callable      $loggerCallable          The logger callable
      */
-    public function __construct(Connection $connection, \MongoDB $mongoDB, EventManager $evm, $numRetries, $loggerCallable)
-    {
+    public function __construct(
+        Connection $connection,
+        \MongoDB $mongoDB,
+        EventManager $evm,
+        Configuration $configuration,
+        $loggerCallable
+    ) {
         if ( ! is_callable($loggerCallable)) {
             throw new \InvalidArgumentException('$loggerCallable must be a valid callback');
         }
-        parent::__construct($connection, $mongoDB, $evm, $numRetries);
+        parent::__construct($connection, $mongoDB, $evm, $configuration);
+
         $this->loggerCallable = $loggerCallable;
     }
 
@@ -165,7 +171,13 @@ class LoggableDatabase extends Database implements Loggable
     {
         $mongoGridFS = $this->mongoDB->getGridFS($prefix);
 
-        return new LoggableGridFS($this, $mongoGridFS, $this->eventManager, $this->numRetries, $this->loggerCallable);
+        return new LoggableGridFS(
+            $this,
+            $mongoGridFS,
+            $this->eventManager,
+            $this->configuration,
+            $this->loggerCallable
+        );
     }
 
     /**
@@ -179,6 +191,12 @@ class LoggableDatabase extends Database implements Loggable
     {
         $mongoCollection = $this->mongoDB->selectCollection($name);
 
-        return new LoggableCollection($this, $mongoCollection, $this->eventManager, $this->numRetries, $this->loggerCallable);
+        return new LoggableCollection(
+            $this,
+            $mongoCollection,
+            $this->eventManager,
+            $this->configuration,
+            $this->loggerCallable
+        );
     }
 }

--- a/lib/Doctrine/MongoDB/LoggableGridFS.php
+++ b/lib/Doctrine/MongoDB/LoggableGridFS.php
@@ -27,19 +27,24 @@ class LoggableGridFS extends GridFS implements Loggable
     use LoggableCollectionTrait;
 
     /**
-     * @param Database     $database    Database to which this collection belongs
+     * @param Database $database Database to which this collection belongs
      * @param \MongoGridFS $mongoGridFS MongoGridFS instance being wrapped
-     * @param EventManager $evm         EventManager instance
-     * @param integer      $numRetries  Number of times to retry queries
-     * @param callable     $loggerCallable  The logger callable
+     * @param EventManager $evm EventManager instance
+     * @param Configuration $configuration
+     * @param callable $loggerCallable The logger callable
      */
-    public function __construct(Database $database, \MongoGridFS $mongoGridFS, EventManager $evm, $numRetries = 0, $loggerCallable = null)
-    {
+    public function __construct(
+        Database $database,
+        \MongoGridFS $mongoGridFS,
+        EventManager $evm,
+        Configuration $configuration,
+        $loggerCallable = null
+    ) {
         if ( ! is_callable($loggerCallable)) {
             throw new \InvalidArgumentException('$loggerCallable must be a valid callback');
         }
 
-        parent::__construct($database, $mongoGridFS, $evm, $numRetries, $loggerCallable);
+        parent::__construct($database, $mongoGridFS, $evm, $configuration);
 
         $this->loggerCallable = $loggerCallable;
     }

--- a/lib/Doctrine/MongoDB/Traits/MillisecondSleepTrait.php
+++ b/lib/Doctrine/MongoDB/Traits/MillisecondSleepTrait.php
@@ -1,0 +1,13 @@
+<?php namespace Doctrine\MongoDB\Traits;
+
+trait MillisecondSleepTrait
+{
+    /**
+     * @param int $ms
+     * @return void
+     */
+    protected function sleepForMs($ms)
+    {
+        usleep($ms * 1000);
+    }
+}

--- a/tests/Doctrine/MongoDB/Tests/CollectionEventsChangingContextTest.php
+++ b/tests/Doctrine/MongoDB/Tests/CollectionEventsChangingContextTest.php
@@ -3,6 +3,7 @@
 namespace Doctrine\MongoDB\Tests;
 
 use Doctrine\Common\EventManager;
+use Doctrine\MongoDB\Configuration;
 use Doctrine\MongoDB\Events;
 use Doctrine\MongoDB\Event\AggregateEventArgs;
 use Doctrine\MongoDB\Event\FindEventArgs;
@@ -16,11 +17,13 @@ class CollectionEventsChangingContextTest extends TestCase
 {
     private $database;
     private $mongoCollection;
+    private $configuration;
 
     public function setUp()
     {
         $this->database = $this->getMockDatabase();
         $this->mongoCollection = $this->getMockMongoCollection();
+        $this->configuration = $this->getMockConfiguration();
     }
 
     public function testAggregate()
@@ -271,7 +274,7 @@ class CollectionEventsChangingContextTest extends TestCase
     private function getMockCollection(EventManager $eventManager, array $methods)
     {
         $collection = $this->getMockBuilder('Doctrine\MongoDB\Collection')
-            ->setConstructorArgs([$this->database, $this->mongoCollection, $eventManager])
+            ->setConstructorArgs([$this->database, $this->mongoCollection, $eventManager, $this->configuration])
             ->setMethods(array_keys($methods))
             ->getMock();
 
@@ -295,6 +298,13 @@ class CollectionEventsChangingContextTest extends TestCase
     private function getMockMongoCollection()
     {
         return $this->getMockBuilder('MongoCollection')
+            ->disableOriginalConstructor()
+            ->getMock();
+    }
+
+    private function getMockConfiguration()
+    {
+        return $this->getMockBuilder(Configuration::class)
             ->disableOriginalConstructor()
             ->getMock();
     }

--- a/tests/Doctrine/MongoDB/Tests/CollectionEventsTest.php
+++ b/tests/Doctrine/MongoDB/Tests/CollectionEventsTest.php
@@ -3,6 +3,7 @@
 namespace Doctrine\MongoDB\Tests;
 
 use Doctrine\Common\EventManager;
+use Doctrine\MongoDB\Configuration;
 use Doctrine\MongoDB\Events;
 use Doctrine\MongoDB\Event\AggregateEventArgs;
 use Doctrine\MongoDB\Event\DistinctEventArgs;
@@ -19,12 +20,14 @@ class CollectionEventsTest extends TestCase
     private $database;
     private $eventManager;
     private $mongoCollection;
+    private $configuration;
 
     public function setUp()
     {
         $this->database = $this->getMockDatabase();
         $this->eventManager = $this->getMockEventManager();
         $this->mongoCollection = $this->getMockMongoCollection();
+        $this->configuration = $this->getMockConfiguration();
     }
 
     public function testAggregate()
@@ -316,7 +319,7 @@ class CollectionEventsTest extends TestCase
     private function getMockCollection(array $methods)
     {
         $collection = $this->getMockBuilder('Doctrine\MongoDB\Collection')
-            ->setConstructorArgs([$this->database, $this->mongoCollection, $this->eventManager])
+            ->setConstructorArgs([$this->database, $this->mongoCollection, $this->eventManager, $this->configuration])
             ->setMethods(array_keys($methods))
             ->getMock();
 
@@ -346,6 +349,13 @@ class CollectionEventsTest extends TestCase
     private function getMockMongoCollection()
     {
         return $this->getMockBuilder('MongoCollection')
+            ->disableOriginalConstructor()
+            ->getMock();
+    }
+
+    private function getMockConfiguration()
+    {
+        return $this->getMockBuilder(Configuration::class)
             ->disableOriginalConstructor()
             ->getMock();
     }

--- a/tests/Doctrine/MongoDB/Tests/CollectionTest.php
+++ b/tests/Doctrine/MongoDB/Tests/CollectionTest.php
@@ -5,6 +5,7 @@ namespace Doctrine\MongoDB\Tests;
 use Doctrine\Common\EventManager;
 use Doctrine\MongoDB\ArrayIterator;
 use Doctrine\MongoDB\Collection;
+use Doctrine\MongoDB\Configuration;
 use Doctrine\MongoDB\Database;
 use MongoCollection;
 use PHPUnit\Framework\Error\Deprecated;
@@ -625,7 +626,7 @@ class CollectionTest extends TestCase
     }
 
     /**
-     * @covers Doctrine\MongoDB\Collection::getIndexInfo
+     * @covers \Doctrine\MongoDB\Collection::getIndexInfo
      * @dataProvider provideIsFieldIndex
      */
     public function testIsFieldIndexed($indexInfo, $field, $expectedResult)
@@ -881,7 +882,7 @@ class CollectionTest extends TestCase
     }
 
     /**
-     * @expectedException PHPUnit_Framework_Error_Deprecated
+     * @expectedException \PHPUnit_Framework_Error_Deprecated
      */
     public function testUpdateShouldTriggerErrorForDeprecatedScalarQueryArgument()
     {
@@ -939,40 +940,41 @@ class CollectionTest extends TestCase
 
     public function testWriteConcernOptionIsConverted()
     {
+        $document = ['x' => 1];
+
         $mongoCollection = $this->getMockMongoCollection();
         $mongoCollection->expects($this->once())
             ->method('insert')
-            ->with(['x' => 1], ['w' => 1]);
+            ->with($document, ['w' => 1]);
 
         $coll = $this->getTestCollection($this->getMockDatabase(), $mongoCollection);
 
-        $document = ['x' => 1];
         $coll->insert($document, ['safe' => true]);
     }
 
     public function testSocketTimeoutOptionIsConverted()
     {
+        $document = ['x' => 1];
         $mongoCollection = $this->getMockMongoCollection();
         $mongoCollection->expects($this->once())
             ->method('insert')
-            ->with(['x' => 1], ['socketTimeoutMS' => 1000]);
+            ->with($document, ['socketTimeoutMS' => 1000]);
 
         $coll = $this->getTestCollection($this->getMockDatabase(), $mongoCollection);
 
-        $document = ['x' => 1];
         $coll->insert($document, ['timeout' => 1000]);
     }
 
     public function testWriteTimeoutOptionIsConverted()
     {
+        $document = ['x' => 1];
         $mongoCollection = $this->getMockMongoCollection();
         $mongoCollection->expects($this->once())
             ->method('insert')
-            ->with(['x' => 1], ['wTimeoutMS' => 1000]);
+            ->with($document, ['wTimeoutMS' => 1000]);
 
         $coll = $this->getTestCollection($this->getMockDatabase(), $mongoCollection);
 
-        $document = ['x' => 1];
         $coll->insert($document, ['wtimeout' => 1000]);
     }
 
@@ -1058,6 +1060,13 @@ class CollectionTest extends TestCase
             ->getMock();
     }
 
+    private function getMockConfiguration()
+    {
+        return $this->getMockBuilder('Doctrine\MongoDB\Configuration')
+            ->disableOriginalConstructor()
+            ->getMock();
+    }
+
     private function getMockMongoCollection()
     {
         $mc = $this->getMockBuilder('MongoCollection')
@@ -1098,12 +1107,24 @@ class CollectionTest extends TestCase
         return $point;
     }
 
-    private function getTestCollection(Database $db = null, MongoCollection $mc = null, EventManager $em = null)
-    {
+    private function getTestCollection(
+        Database $db = null,
+        MongoCollection $mc = null,
+        EventManager $em = null,
+        Configuration $cfg = null
+    ) {
+        /** @var Database $db */
         $db = $db ?: $this->getMockDatabase();
+
+        /** @var MongoCollection $mc */
         $mc = $mc ?: $this->getMockMongoCollection();
+
+        /** @var EventManager $em */
         $em = $em ?: $this->getMockEventManager();
 
-        return new Collection($db, $mc, $em);
+        /** @var Configuration $cfg */
+        $cfg = $cfg ?: $this->getMockConfiguration();
+
+        return new Collection($db, $mc, $em, $cfg);
     }
 }

--- a/tests/Doctrine/MongoDB/Tests/CollectionWriteRetryWriteRetryTest.php
+++ b/tests/Doctrine/MongoDB/Tests/CollectionWriteRetryWriteRetryTest.php
@@ -1,0 +1,371 @@
+<?php namespace Doctrine\MongoDB\Tests;
+
+use Doctrine\Common\EventManager;
+use Doctrine\MongoDB\Collection;
+use Doctrine\MongoDB\Configuration;
+use Doctrine\MongoDB\Database;
+
+class CollectionWriteRetryTest extends TestCase
+{
+    /** @var Database|\PHPUnit_Framework_MockObject_MockObject */
+    private $database;
+
+    /** @var \MongoCollection|\PHPUnit_Framework_MockObject_MockObject */
+    private $mongo_collection;
+
+    /** @var Configuration */
+    private $configuration;
+
+    /** @var CollectionWriteRetryTestDouble */
+    private $collection;
+
+    protected function setUp()
+    {
+        parent::setUp();
+
+        $this->database = $this->getMockDatabase();
+        $this->mongo_collection = $this->getMockMongoCollection();
+        $event_manager = new EventManager();
+
+        $this->configuration = new Configuration();
+
+        $this->collection = new CollectionWriteRetryTestDouble(
+            $this->database,
+            $this->mongo_collection,
+            $event_manager,
+            $this->configuration
+        );
+    }
+
+    /**
+     * @covers Collection::retryInsert()
+     */
+    public function testRetryInsertClosureReturnedImmediatelyIfRetriesLessThanOne()
+    {
+        $this->configuration->setNumRetryWrites(false);
+
+        $doc = ['x' => 1];
+
+        try {
+            $this->collection->insert($doc);
+        } catch (\MongoConnectionException $exception) {}
+
+        $this->assertEquals(1, $this->collection->times_attempted);
+
+        $this->configuration->setNumRetryWrites(-123);
+
+        try {
+            $this->collection->insert($doc);
+        } catch (\MongoConnectionException $exception) {}
+
+        $this->assertEquals(1, $this->collection->times_attempted);
+    }
+
+    /**
+     * @covers Collection::retryInsert()
+     */
+    public function testRetryInsertOnlyIgnoresDuplicateKeyExceptionsForDefaultIdIndex()
+    {
+        $this->configuration->setNumRetryWrites(1);
+        $doc = ['x' => 1];
+
+        $correct_exception = new \MongoDuplicateKeyException('This should pass: _id_ dup key: { : 1 }');
+        $incorrect_exception = new \MongoDuplicateKeyException('This should fail: _id_field_1 dup key: { : 1 }');
+
+        $this->collection->exception = [new \MongoConnectionException(), $incorrect_exception];
+
+        $last_caught_exception = null;
+
+        try {
+            $this->collection->insert($doc);
+        } catch (\MongoDuplicateKeyException $exception) {
+            $last_caught_exception = $exception;
+            $this->collection->exception = [new \MongoConnectionException(), $correct_exception];
+
+            try {
+                $this->collection->insert($doc);
+                $this->assertEquals(2, $this->collection->times_attempted);
+            } catch (\MongoDuplicateKeyException $exception) {
+                $this->fail("Duplicate key exception for only id should be successful on 1+ iterations.");
+            }
+        }
+
+        $this->assertInstanceOf(\MongoDuplicateKeyException::class, $last_caught_exception);
+    }
+
+    /**
+     * @covers Collection::retryInsert()
+     */
+    public function testRetryInsertOnlyIgnoresDuplicateKeyExceptionsBeyondFirstRetryIteration()
+    {
+        $this->configuration->setNumRetryWrites(2);
+
+        $doc = ['x' => 1];
+
+        $this->collection->exception = [
+            new \MongoConnectionException(),
+            new \MongoDuplicateKeyException('E11000 duplicate key error index: test. _id_ dup key: { : 1 }')
+        ];
+        try {
+            $this->collection->insert($doc);
+        } catch (\MongoDuplicateKeyException $exception) {
+            $this->fail("Exception should not have been bubbled up; it should have been successful");
+        }
+
+        $this->assertEquals(2, $this->collection->times_attempted);
+    }
+
+    /**
+     * @covers Collection::retryInsert()
+     */
+    public function testRetryInsertGeneratesIdIfDocumentHasNone()
+    {
+        $this->configuration->setNumRetryWrites(1);
+
+        $doc = ['x' => 1];
+
+        $this->assertFalse(isset($doc['_id']), "This test relies on the _id field of the doc being empty.");
+
+        $this->collection->insert($doc);
+
+        $this->assertTrue(isset($doc['_id']));
+        $this->assertInstanceOf(\MongoId::class, $doc['_id']);
+    }
+
+    /**
+     * @covers Collection::retryBatchInsert()
+     */
+    public function testBatchInsertGeneratesIdIfObjectsOrArraysHaveNone()
+    {
+        $this->configuration->setNumRetryWrites(1);
+
+        $docs = [
+            (object) ['x' => 1],
+            ['y' => 1],
+        ];
+
+        $this->assertFalse(isset($docs[0]->_id));
+        $this->assertFalse(isset($docs[1]['_id']));
+
+        $this->collection->batchInsert($docs);
+
+        $this->assertTrue(isset($docs[0]->_id));
+        $this->assertInstanceOf(\MongoId::class, $docs[0]->_id);
+        $this->assertTrue(isset($docs[1]['_id']));
+        $this->assertInstanceOf(\MongoId::class, $docs[1]['_id']);
+    }
+
+    /**
+     * @covers Collection::retryBatchInsert()
+     */
+    public function testRetryBatchInsertReturnsClosureImmediatelyIfRetriesLessThanOne()
+    {
+        $this->configuration->setNumRetryWrites(0);
+
+        $docs = [
+            (object) ['x' => 1],
+            ['y' => 1],
+        ];
+
+        $this->collection->batchInsert($docs);
+        $this->assertEquals(1, $this->collection->times_attempted);
+
+        $this->configuration->setNumRetryWrites(-1000);
+
+        $this->collection->batchInsert($docs);
+        $this->assertEquals(1, $this->collection->times_attempted);
+    }
+
+    /**
+     * @covers Collection::retryBatchInsert()
+     */
+    public function testRetryBatchInsertContinuesOnErrorIterationsBeyondTheFirst()
+    {
+        $this->configuration->setNumRetryWrites(1);
+
+        $docs = [
+            [
+                'x' => 1,
+            ],
+            [
+                'y' => 1,
+            ]
+        ];
+
+        $this->collection->exception = [new \MongoConnectionException(), new \MongoDuplicateKeyException()];
+
+        try {
+            $this->collection->batchInsert($docs);
+        } catch (\MongoDuplicateKeyException $exception) {}
+
+        $this->assertEquals(2, $this->collection->times_attempted);
+        $this->assertTrue(isset($this->collection->batch_insert_options['continueOnError']));
+        $this->assertTrue($this->collection->batch_insert_options['continueOnError']);
+    }
+
+    /**
+     * @covers Collection::retryBatchInsert()
+     */
+    public function testRetryBatchInsertRevertsContinueOnErrorOptionToPreviousValueWhenRetriesFinishSuccessfully()
+    {
+        $this->configuration->setNumRetryWrites(1);
+
+        $docs = [
+            [
+                'x' => 1,
+            ],
+            [
+                'y' => 1,
+            ]
+        ];
+
+        $options = ['continueOnError' => 'test'];
+
+        $this->collection->exception = [new \MongoConnectionException()];
+
+        $this->collection->batchInsert($docs, $options);
+
+        $this->assertEquals(2, $this->collection->times_attempted);
+        $this->assertEquals($options, $this->collection->batch_insert_options);
+
+        $this->collection->batchInsert($docs);
+
+        $this->assertEquals(2, $this->collection->times_attempted);
+        $this->assertFalse(isset($this->collection->batch_insert_options['continueOnError']));
+    }
+
+    /**
+     * @covers Collection::retryIdempotentUpdate()
+     */
+    public function testRetryUpdateImmediatelyReturnsClosureIfNumberOfRetriesLessThanOne()
+    {
+        $this->configuration->setNumRetryWrites(0);
+
+        $update = [ '$set' => [ 'field' => 'value' ] ];
+
+        $this->collection->update([], $update);
+        $this->assertEquals(1, $this->collection->times_attempted);
+
+        $this->configuration->setNumRetryWrites(-1000);
+
+        $this->collection->update([], $update);
+        $this->assertEquals(1, $this->collection->times_attempted);
+    }
+
+    /**
+     * @covers Collection::retryIdempotentUpdate()
+     */
+    public function testRetryUpdateImmediatelyReturnsClosureOnNonIdempotentOperations()
+    {
+        $this->configuration->setNumRetryWrites(5);
+
+        $inc = [ '$inc' => [ 'field' => 1 ] ];
+        $current_date = [ '$currentDate' => [ 'field' => [ '$type' => 'timestamp' ] ] ];
+        $mul = [ '$mul' => [ 'field' => 2 ] ];
+        $pop = [ '$pop' => [ 'field' => -1 ] ];
+        $push = [ '$push' => [ 'field' => [ '$each' => [ 'value1', 'value2' ] ] ] ];
+        $pushAll = [ '$pushAll' => [ 'value1', 'value2' ] ];
+        $bit = [ 'field' => [ 'and' => 1 ] ];
+
+        $disallowed_update_retry_operators = [
+            $inc,
+            $current_date,
+            $mul,
+            $pop,
+            $push,
+            $pushAll,
+            $bit,
+        ];
+
+        foreach ($disallowed_update_retry_operators as $operator) {
+            $this->collection->update([], $operator);
+
+            $this->assertEquals(1, $this->collection->times_attempted);
+        }
+    }
+
+    /**
+     * @return Database|\PHPUnit_Framework_MockObject_MockObject
+     */
+    private function getMockDatabase()
+    {
+        return $this->getMockBuilder(Database::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+    }
+
+    /**
+     * @return \MongoCollection|\PHPUnit_Framework_MockObject_MockObject
+     */
+    private function getMockMongoCollection()
+    {
+        return $this->getMockBuilder(\MongoCollection::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+    }
+}
+
+class CollectionWriteRetryTestDouble extends Collection
+{
+    public $times_attempted;
+
+    public $exception;
+
+    public $batch_insert_options;
+
+    protected function doInsert(array &$a, array $options)
+    {
+        $closure = $this->getTestRetryClosure();
+
+        return $this->retryInsert($closure, $a);
+    }
+
+    protected function doBatchInsert(array &$a, array $options = [])
+    {
+        $options_to_pass = $options;
+
+        $this->batch_insert_options =& $options_to_pass;
+
+        $closure = $this->getTestRetryClosure();
+
+        return $this->retryBatchInsert($closure, $options_to_pass, ...$a);
+    }
+
+    protected function doUpdate(array $query, array $newObj, array $options)
+    {
+        $closure = $this->getTestRetryClosure();
+
+        return $this->retryIdempotentUpdate($closure, $newObj);
+    }
+
+    private function getTestRetryClosure()
+    {
+        $this->times_attempted = 0;
+
+        $closure = function () {
+            if (is_array($this->exception)) {
+                foreach ($this->exception as $iteration => $exception) {
+                    /** @var \Exception $exception */
+                    /** @var int $iteration */
+                    if ($this->times_attempted === $iteration) {
+                        $this->times_attempted++;
+                        throw $exception;
+                    }
+                }
+            } else if ($this->exception instanceof \Exception) {
+                throw $this->exception;
+            }
+
+            $this->times_attempted++;
+            return true;
+        };
+
+        return $closure;
+    }
+
+    protected function sleepForMs($ms)
+    {
+        // Disabled so we don't end up delaying tests by significant time periods; this can be tested on it's own
+        // since it's a singular unit
+    }
+}

--- a/tests/Doctrine/MongoDB/Tests/CommandCursorFunctionalTest.php
+++ b/tests/Doctrine/MongoDB/Tests/CommandCursorFunctionalTest.php
@@ -2,8 +2,11 @@
 
 namespace Doctrine\MongoDB\Tests;
 
+use Doctrine\MongoDB\Collection;
+
 class CommandCursorFunctionalTest extends DatabaseTestCase
 {
+    /** @var Collection */
     private $collection;
     private $docs;
 
@@ -64,7 +67,7 @@ class CommandCursorFunctionalTest extends DatabaseTestCase
     }
 
     /**
-     * @covers Doctrine\MongoDB\Cursor::getSingleResult
+     * @covers \Doctrine\MongoDB\Cursor::getSingleResult
      */
     public function testGetSingleResultReturnsNullForEmptyResultSet()
     {

--- a/tests/Doctrine/MongoDB/Tests/CommandCursorTest.php
+++ b/tests/Doctrine/MongoDB/Tests/CommandCursorTest.php
@@ -3,6 +3,7 @@
 namespace Doctrine\MongoDB\Tests;
 
 use Doctrine\MongoDB\CommandCursor;
+use Doctrine\MongoDB\Configuration;
 
 class CommandCursorTest extends TestCase
 {
@@ -21,7 +22,9 @@ class CommandCursorTest extends TestCase
             ->method('batchSize')
             ->with(10);
 
-        $commandCursor = new CommandCursor($mongoCommandCursor);
+        $configuration = $this->getMockConfiguration();
+
+        $commandCursor = new CommandCursor($mongoCommandCursor, $configuration);
         $this->assertSame($commandCursor, $commandCursor->batchSize(10));
     }
 
@@ -33,14 +36,17 @@ class CommandCursorTest extends TestCase
             ->method('dead')
             ->will($this->returnValue(true));
 
-        $commandCursor = new CommandCursor($mongoCommandCursor);
+        $configuration = $this->getMockConfiguration();
+
+        $commandCursor = new CommandCursor($mongoCommandCursor, $configuration);
         $this->assertTrue($commandCursor->dead());
     }
 
     public function testGetMongoCommandCursor()
     {
         $mongoCommandCursor = $this->getMockMongoCommandCursor();
-        $commandCursor = new CommandCursor($mongoCommandCursor);
+        $configuration = $this->getMockConfiguration();
+        $commandCursor = new CommandCursor($mongoCommandCursor, $configuration);
         $this->assertSame($mongoCommandCursor, $commandCursor->getMongoCommandCursor());
     }
 
@@ -52,7 +58,9 @@ class CommandCursorTest extends TestCase
             ->method('info')
             ->will($this->returnValue(['info']));
 
-        $commandCursor = new CommandCursor($mongoCommandCursor);
+        $configuration = $this->getMockConfiguration();
+
+        $commandCursor = new CommandCursor($mongoCommandCursor, $configuration);
         $this->assertEquals(['info'], $commandCursor->info());
     }
 
@@ -68,7 +76,9 @@ class CommandCursorTest extends TestCase
             ->method('timeout')
             ->with(1000);
 
-        $commandCursor = new CommandCursor($mongoCommandCursor);
+        $configuration = $this->getMockConfiguration();
+
+        $commandCursor = new CommandCursor($mongoCommandCursor, $configuration);
         $this->assertSame($commandCursor, $commandCursor->timeout(1000));
     }
 
@@ -81,13 +91,26 @@ class CommandCursorTest extends TestCase
             $this->markTestSkipped('This test is not applicable to drivers with MongoCommandCursor::timeout()');
         }
 
-        $commandCursor = new CommandCursor($this->getMockMongoCommandCursor());
+        $commandCursor = new CommandCursor($this->getMockMongoCommandCursor(), $this->getMockConfiguration());
         $commandCursor->timeout(1000);
     }
 
+    /**
+     * @return \MongoCommandCursor|\PHPUnit_Framework_MockObject_MockObject
+     */
     private function getMockMongoCommandCursor()
     {
         return $this->getMockBuilder('MongoCommandCursor')
+            ->disableOriginalConstructor()
+            ->getMock();
+    }
+
+    /**
+     * @return Configuration|\PHPUnit_Framework_MockObject_MockObject
+     */
+    private function getMockConfiguration()
+    {
+        return $this->getMockBuilder(Configuration::class)
             ->disableOriginalConstructor()
             ->getMock();
     }

--- a/tests/Doctrine/MongoDB/Tests/DatabaseEventsTest.php
+++ b/tests/Doctrine/MongoDB/Tests/DatabaseEventsTest.php
@@ -3,23 +3,29 @@
 namespace Doctrine\MongoDB\Tests;
 
 use Doctrine\Common\EventManager;
+use Doctrine\MongoDB\Collection;
+use Doctrine\MongoDB\Configuration;
+use Doctrine\MongoDB\Connection;
 use Doctrine\MongoDB\Database;
 use Doctrine\MongoDB\Events;
 use Doctrine\MongoDB\Event\CreateCollectionEventArgs;
 use Doctrine\MongoDB\Event\EventArgs;
 use Doctrine\MongoDB\Event\MutableEventArgs;
+use Doctrine\MongoDB\GridFS;
 
 class DatabaseEventsTest extends TestCase
 {
     private $connection;
     private $eventManager;
     private $mongoDB;
+    private $configuration;
 
     public function setUp()
     {
         $this->connection = $this->getMockConnection();
         $this->eventManager = $this->getMockEventManager();
         $this->mongoDB = $this->getMockMongoDB();
+        $this->configuration = $this->getMockConfiguration();
     }
 
     public function testCreateCollection()
@@ -46,7 +52,7 @@ class DatabaseEventsTest extends TestCase
             ->method('drop')
             ->will($this->returnValue($result));
 
-        $db = new Database($this->connection, $this->mongoDB, $this->eventManager);
+        $db = new Database($this->connection, $this->mongoDB, $this->eventManager, $this->configuration);
 
         $this->expectEvents([
             [Events::preDropDatabase, new EventArgs($db)],
@@ -127,6 +133,9 @@ class DatabaseEventsTest extends TestCase
         }
     }
 
+    /**
+     * @return Collection|\PHPUnit_Framework_MockObject_MockObject
+     */
     private function getMockCollection()
     {
         return $this->getMockBuilder('Doctrine\MongoDB\Collection')
@@ -134,6 +143,9 @@ class DatabaseEventsTest extends TestCase
             ->getMock();
     }
 
+    /**
+     * @return Connection|\PHPUnit_Framework_MockObject_MockObject
+     */
     private function getMockConnection()
     {
         return $this->getMockBuilder('Doctrine\MongoDB\Connection')
@@ -141,10 +153,14 @@ class DatabaseEventsTest extends TestCase
             ->getMock();
     }
 
+    /**
+     * @param array $methods
+     * @return Database|\PHPUnit_Framework_MockObject_MockObject
+     */
     private function getMockDatabase(array $methods = [])
     {
         $db = $this->getMockBuilder('Doctrine\MongoDB\Database')
-            ->setConstructorArgs([$this->connection, $this->mongoDB, $this->eventManager])
+            ->setConstructorArgs([$this->connection, $this->mongoDB, $this->eventManager, $this->configuration])
             ->setMethods(array_keys($methods))
             ->getMock();
 
@@ -157,6 +173,9 @@ class DatabaseEventsTest extends TestCase
         return $db;
     }
 
+    /**
+     * @return EventManager|\PHPUnit_Framework_MockObject_MockObject
+     */
     private function getMockEventManager()
     {
         return $this->getMockBuilder('Doctrine\Common\EventManager')
@@ -164,6 +183,9 @@ class DatabaseEventsTest extends TestCase
             ->getMock();
     }
 
+    /**
+     * @return GridFS|\PHPUnit_Framework_MockObject_MockObject
+     */
     private function getMockGridFS()
     {
         return $this->getMockBuilder('Doctrine\MongoDB\GridFS')
@@ -171,9 +193,22 @@ class DatabaseEventsTest extends TestCase
             ->getMock();
     }
 
+    /**
+     * @return \MongoDB|\PHPUnit_Framework_MockObject_MockObject
+     */
     private function getMockMongoDB()
     {
         return $this->getMockBuilder('MongoDB')
+            ->disableOriginalConstructor()
+            ->getMock();
+    }
+
+    /**
+     * @return Configuration|\PHPUnit_Framework_MockObject_MockObject
+     */
+    private function getMockConfiguration()
+    {
+        return $this->getMockBuilder('Doctrine\MongoDB\Configuration')
             ->disableOriginalConstructor()
             ->getMock();
     }

--- a/tests/Doctrine/MongoDB/Tests/DatabaseTest.php
+++ b/tests/Doctrine/MongoDB/Tests/DatabaseTest.php
@@ -2,6 +2,9 @@
 
 namespace Doctrine\MongoDB\Tests;
 
+use Doctrine\Common\EventManager;
+use Doctrine\MongoDB\Configuration;
+use Doctrine\MongoDB\Connection;
 use Doctrine\MongoDB\Database;
 
 class DatabaseTest extends TestCase
@@ -14,7 +17,12 @@ class DatabaseTest extends TestCase
             ->method('command')
             ->will($this->returnArgument(2));
 
-        $database = new Database($this->getMockConnection(), $mongoDB, $this->getMockEventManager());
+        $database = new Database(
+            $this->getMockConnection(),
+            $mongoDB,
+            $this->getMockEventManager(),
+            $this->getMockConfiguration()
+        );
 
         $hash = true;
         $this->assertTrue($database->command(['count' => 'foo'], [], $hash));
@@ -34,7 +42,12 @@ class DatabaseTest extends TestCase
             ->with('foo')
             ->will($this->returnValue($this->getMockMongoCollection()));
 
-        $database = new Database($this->getMockConnection(), $mongoDB, $this->getMockEventManager());
+        $database = new Database(
+            $this->getMockConnection(),
+            $mongoDB,
+            $this->getMockEventManager(),
+            $this->getMockConfiguration()
+        );
         $collection = $database->createCollection('foo', true, 10485760, 0);
 
         $this->assertInstanceOf('Doctrine\MongoDB\Collection', $collection);
@@ -53,7 +66,12 @@ class DatabaseTest extends TestCase
             ->with('foo')
             ->will($this->returnValue($this->getMockMongoCollection()));
 
-        $database = new Database($this->getMockConnection(), $mongoDB, $this->getMockEventManager());
+        $database = new Database(
+            $this->getMockConnection(),
+            $mongoDB,
+            $this->getMockEventManager(),
+            $this->getMockConfiguration()
+        );
         $collection = $database->createCollection('foo', ['capped' => true, 'size' => 10485760, 'autoIndexId' => false]);
 
         $this->assertInstanceOf('Doctrine\MongoDB\Collection', $collection);
@@ -72,7 +90,12 @@ class DatabaseTest extends TestCase
             ->with('foo')
             ->will($this->returnValue($this->getMockMongoCollection()));
 
-        $database = new Database($this->getMockConnection(), $mongoDB, $this->getMockEventManager());
+        $database = new Database(
+            $this->getMockConnection(),
+            $mongoDB,
+            $this->getMockEventManager(),
+            $this->getMockConfiguration()
+        );
         $collection = $database->createCollection('foo', ['capped' => 0, 'size' => null, 'max' => null]);
 
         $this->assertInstanceOf('Doctrine\MongoDB\Collection', $collection);
@@ -96,7 +119,12 @@ class DatabaseTest extends TestCase
             ->with(\MongoClient::RP_SECONDARY_PREFERRED)
             ->will($this->returnValue(false));
 
-        $database = new Database($this->getMockConnection(), $mongoDB, $this->getMockEventManager());
+        $database = new Database(
+            $this->getMockConnection(),
+            $mongoDB,
+            $this->getMockEventManager(),
+            $this->getMockConfiguration()
+        );
 
         $this->assertEquals(false, $database->setSlaveOkay(true));
     }
@@ -117,7 +145,12 @@ class DatabaseTest extends TestCase
             ->with(\MongoClient::RP_SECONDARY_PREFERRED, [['dc' => 'east']])
             ->will($this->returnValue(false));
 
-        $database = new Database($this->getMockConnection(), $mongoDB, $this->getMockEventManager());
+        $database = new Database(
+            $this->getMockConnection(),
+            $mongoDB,
+            $this->getMockEventManager(),
+            $this->getMockConfiguration()
+        );
 
         $this->assertEquals(true, $database->setSlaveOkay(true));
     }
@@ -136,7 +169,12 @@ class DatabaseTest extends TestCase
             ->with(\MongoClient::RP_SECONDARY_PREFERRED, [['dc' => 'east']])
             ->will($this->returnValue(true));
 
-        $database = new Database($this->getMockConnection(), $mongoDB, $this->getMockEventManager());
+        $database = new Database(
+            $this->getMockConnection(),
+            $mongoDB,
+            $this->getMockEventManager(),
+            $this->getMockConfiguration()
+        );
 
         $this->assertTrue($database->setReadPreference(\MongoClient::RP_PRIMARY));
         $this->assertTrue($database->setReadPreference(\MongoClient::RP_SECONDARY_PREFERRED, [['dc' => 'east']]));
@@ -149,11 +187,19 @@ class DatabaseTest extends TestCase
             ->method('command')
             ->with(['count' => 'foo'], ['socketTimeoutMS' => 1000]);
 
-        $database = new Database($this->getMockConnection(), $mongoDB, $this->getMockEventManager());
+        $database = new Database(
+            $this->getMockConnection(),
+            $mongoDB,
+            $this->getMockEventManager(),
+            $this->getMockConfiguration()
+        );
 
         $database->command(['count' => 'foo'], ['timeout' => 1000]);
     }
 
+    /**
+     * @return \PHPUnit_Framework_MockObject_MockObject|Connection
+     */
     private function getMockConnection()
     {
         return $this->getMockBuilder('Doctrine\MongoDB\Connection')
@@ -161,6 +207,9 @@ class DatabaseTest extends TestCase
             ->getMock();
     }
 
+    /**
+     * @return \PHPUnit_Framework_MockObject_MockObject|EventManager
+     */
     private function getMockEventManager()
     {
         return $this->getMockBuilder('Doctrine\Common\EventManager')
@@ -168,6 +217,9 @@ class DatabaseTest extends TestCase
             ->getMock();
     }
 
+    /**
+     * @return \PHPUnit_Framework_MockObject_MockObject|\MongoCollection
+     */
     private function getMockMongoCollection()
     {
         return $this->getMockBuilder('MongoCollection')
@@ -175,6 +227,19 @@ class DatabaseTest extends TestCase
             ->getMock();
     }
 
+    /**
+     * @return \PHPUnit_Framework_MockObject_MockObject|Configuration
+     */
+    private function getMockConfiguration()
+    {
+        return $this->getMockBuilder('Doctrine\MongoDB\Configuration')
+            ->disableOriginalConstructor()
+            ->getMock();
+    }
+
+    /**
+     * @return \PHPUnit_Framework_MockObject_MockObject|\MongoDB
+     */
     private function getMockMongoDB()
     {
         return $this->getMockBuilder('MongoDB')

--- a/tests/Doctrine/MongoDB/Tests/DatabaseTestCase.php
+++ b/tests/Doctrine/MongoDB/Tests/DatabaseTestCase.php
@@ -9,6 +9,7 @@ abstract class DatabaseTestCase extends TestCase
 {
     protected static $dbName = 'doctrine_mongodb';
 
+    /** @var Connection */
     protected $conn;
 
     public function setUp()

--- a/tests/Doctrine/MongoDB/Tests/LoggableCollectionTest.php
+++ b/tests/Doctrine/MongoDB/Tests/LoggableCollectionTest.php
@@ -2,6 +2,9 @@
 
 namespace Doctrine\MongoDB\Tests;
 
+use Doctrine\Common\EventManager;
+use Doctrine\MongoDB\Configuration;
+use Doctrine\MongoDB\Database;
 use Doctrine\MongoDB\LoggableCollection;
 
 class LoggableCollectionTest extends TestCase
@@ -25,6 +28,7 @@ class LoggableCollectionTest extends TestCase
 
     private function getTestLoggableCollection($loggerCallable)
     {
+        /** @var \PHPUnit_Framework_MockObject_MockObject|Database $database */
         $database = $this->getMockBuilder('Doctrine\MongoDB\Database')
             ->disableOriginalConstructor()
             ->getMock();
@@ -33,6 +37,7 @@ class LoggableCollectionTest extends TestCase
             ->method('getName')
             ->will($this->returnValue(self::databaseName));
 
+        /** @var \PHPUnit_Framework_MockObject_MockObject|\MongoCollection $mongoCollection */
         $mongoCollection = $this->getMockBuilder('MongoCollection')
             ->disableOriginalConstructor()
             ->getMock();
@@ -41,10 +46,16 @@ class LoggableCollectionTest extends TestCase
             ->method('getName')
             ->will($this->returnValue(self::collectionName));
 
+        /** @var EventManager|\PHPUnit_Framework_MockObject_MockObject $eventManager */
         $eventManager = $this->getMockBuilder('Doctrine\Common\EventManager')
             ->disableOriginalConstructor()
             ->getMock();
 
-        return new LoggableCollection($database, $mongoCollection, $eventManager, 0, $loggerCallable);
+        /** @var Configuration|\PHPUnit_Framework_MockObject_MockObject $configuration */
+        $configuration = $this->getMockBuilder('Doctrine\MongoDB\Configuration')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        return new LoggableCollection($database, $mongoCollection, $eventManager, $configuration, $loggerCallable);
     }
 }

--- a/tests/Doctrine/MongoDB/Tests/LoggableDatabaseTest.php
+++ b/tests/Doctrine/MongoDB/Tests/LoggableDatabaseTest.php
@@ -2,6 +2,9 @@
 
 namespace Doctrine\MongoDB\Tests;
 
+use Doctrine\Common\EventManager;
+use Doctrine\MongoDB\Configuration;
+use Doctrine\MongoDB\Connection;
 use Doctrine\MongoDB\LoggableDatabase;
 
 class LoggableDatabaseTest extends TestCase
@@ -24,10 +27,12 @@ class LoggableDatabaseTest extends TestCase
 
     private function getTestLoggableDatabase($loggerCallable)
     {
+        /** @var Connection|\PHPUnit_Framework_MockObject_MockObject $connection */
         $connection = $this->getMockBuilder('Doctrine\MongoDB\Connection')
             ->disableOriginalConstructor()
             ->getMock();
 
+        /** @var \MongoDB|\PHPUnit_Framework_MockObject_MockObject $mongoDB */
         $mongoDB = $this->getMockBuilder('MongoDB')
             ->disableOriginalConstructor()
             ->getMock();
@@ -36,10 +41,22 @@ class LoggableDatabaseTest extends TestCase
             ->method('__toString')
             ->will($this->returnValue(self::databaseName));
 
+        /** @var EventManager|\PHPUnit_Framework_MockObject_MockObject $eventManager */
         $eventManager = $this->getMockBuilder('Doctrine\Common\EventManager')
             ->disableOriginalConstructor()
             ->getMock();
 
-        return new LoggableDatabase($connection, $mongoDB, $eventManager, 0, $loggerCallable);
+        /** @var Configuration|\PHPUnit_Framework_MockObject_MockObject $configuration */
+        $configuration = $this->getMockBuilder('Doctrine\MongoDB\Configuration')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        return new LoggableDatabase(
+            $connection,
+            $mongoDB,
+            $eventManager,
+            $configuration,
+            $loggerCallable
+        );
     }
 }

--- a/tests/Doctrine/MongoDB/Tests/LoggableGridFSTest.php
+++ b/tests/Doctrine/MongoDB/Tests/LoggableGridFSTest.php
@@ -2,9 +2,9 @@
 
 namespace Doctrine\MongoDB\Tests;
 
+use Doctrine\MongoDB\Configuration;
 use MongoGridFS;
 use MongoGridFSFile;
-use Doctrine\MongoDB\GridFSFile;
 use Doctrine\MongoDB\LoggableGridFS;
 use Doctrine\MongoDB\Database;
 use Doctrine\Common\EventManager;
@@ -13,6 +13,9 @@ class LoggableGridFSTest extends TestCase
 {
     const COLLECTION_NAME = 'collectionName';
     const DATABASE_NAME = 'databaseName';
+
+    /** @var \PHPUnit_Framework_MockObject_MockObject|MongoGridFS */
+    private $mongoGridFS;
 
     public function testLog()
     {
@@ -39,7 +42,7 @@ class LoggableGridFSTest extends TestCase
             ->disableOriginalConstructor()
             ->getMock();
 
-        $this->mongoCollection->expects($this->any())
+        $this->mongoGridFS->expects($this->any())
             ->method('get')
             ->will($this->returnValue($mongoGridFSFile));
 
@@ -66,6 +69,7 @@ class LoggableGridFSTest extends TestCase
 
     private function getLoggableGridFS($loggerCallable)
     {
+        /** @var \PHPUnit_Framework_MockObject_MockObject|Database $database */
         $database = $this->getMockBuilder(Database::class)
             ->disableOriginalConstructor()
             ->getMock();
@@ -74,18 +78,24 @@ class LoggableGridFSTest extends TestCase
             ->method('getName')
             ->will($this->returnValue(self::DATABASE_NAME));
 
-        $this->mongoCollection = $this->getMockBuilder(MongoGridFS::class)
+        $this->mongoGridFS = $this->getMockBuilder(MongoGridFS::class)
             ->disableOriginalConstructor()
             ->getMock();
 
-        $this->mongoCollection->expects($this->any())
+        $this->mongoGridFS->expects($this->any())
             ->method('getName')
             ->will($this->returnValue(self::COLLECTION_NAME));
 
+        /** @var EventManager|\PHPUnit_Framework_MockObject_MockObject $eventManager */
         $eventManager = $this->getMockBuilder(EventManager::class)
             ->disableOriginalConstructor()
             ->getMock();
 
-        return new LoggableGridFS($database, $this->mongoCollection, $eventManager, 0, $loggerCallable);
+        /** @var Configuration|\PHPUnit_Framework_MockObject_MockObject $configuration */
+        $configuration = $this->getMockBuilder(Configuration::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        return new LoggableGridFS($database, $this->mongoGridFS, $eventManager, $configuration, $loggerCallable);
     }
 }

--- a/tests/Doctrine/MongoDB/Tests/Traits/MillisecondSleepTraitTest.php
+++ b/tests/Doctrine/MongoDB/Tests/Traits/MillisecondSleepTraitTest.php
@@ -1,0 +1,21 @@
+<?php namespace Doctrine\MongoDB\Tests\Traits;
+
+use Doctrine\MongoDB\Tests\TestCase;
+use Doctrine\MongoDB\Traits\MillisecondSleepTrait;
+
+class MillisecondSleepTraitTest extends TestCase
+{
+    use MillisecondSleepTrait;
+
+    public function testSleepForMilliseconds()
+    {
+        $sleep_time_ms = 100;
+
+        $start_time_ms = round(microtime(true) * 1000);
+        $this->sleepForMs($sleep_time_ms);
+        $end_time_ms = round(microtime(true) * 1000);
+
+        $execution_time_ms = round($end_time_ms - $start_time_ms);
+        $this->assertGreaterThanOrEqual($sleep_time_ms, $execution_time_ms);
+    }
+}

--- a/tests/Doctrine/MongoDB/Tests/Util/ReadPreferenceTest.php
+++ b/tests/Doctrine/MongoDB/Tests/Util/ReadPreferenceTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Doctrine\Tests\MongoDB\Util;
+namespace Doctrine\MongoDB\Tests\Util;
 
 use Doctrine\MongoDB\Util\ReadPreference;
 use Doctrine\MongoDB\Tests\TestCase;
@@ -8,7 +8,7 @@ use Doctrine\MongoDB\Tests\TestCase;
 class ReadPreferenceTest extends TestCase
 {
     /**
-     * @expectedException InvalidArgumentException
+     * @expectedException \InvalidArgumentException
      */
     public function testConvertNumericTypeShouldThrowExceptionForInvalidType()
     {


### PR DESCRIPTION
# Overview

This PR consists of a much more fleshed out command retry implementation comprising both read and write operations.

> Note that the changes contained in this PR won't be enough to implement write retries when using the newer [PHP MongoDB userland library](https://docs.mongodb.com/php-library/current/) and [driver](https://secure.php.net/manual/en/set.mongodb.php) in tandem with [Alcaeus' mongo-php-adapter](https://github.com/alcaeus/mongo-php-adapter) for e.g. Doctrine's ODM. That requires a bit more patches on the adapter side to be applied to an existing project as well, explained below in it's sub-section.

There's a lot of changes that are a bit strange to look at and require a bit of in-depth reading in external documentation. I'll be explaining pretty much all of it in the following sections.

## Motivations

Why did this feature come up especially since MongoDB is slated to have much cleaner, safer, and more exhaustive retry options available [coming in 3.6](https://emptysqua.re/blog/driver-features-for-mongodb-3-6/)?

Even with the feature slated to come, a backwards-compatible implementation (even if it is a bit limited) that can be utilized client-side is likely to find some very good use.

## Goals

The desired feature is the very title: write retries that could handle connectivity issues that could occur during primary re-elections and fail-overs.

It also needed to be **safe**: everything had to be as idempotent as possible to reduce the risk of e.g. documents being inserted more than once due to a response timeout (but command execution server-side) issue.

This required some very minor refactoring and quite a lot of additions and considerations to the possibilities that the driver (and thus wrapper) offer to implementing applications.


# `Collection.php`

The majority of the changes in this PR lie in the `Collection` class since it's the main hook into performing various operations targeting a collection in MongoDB.

The three biggest ones are the distinct retry functions for each specific write operation: singular inserts, batch inserts, and updates.

### Singular inserts

Singular inserts are the easiest functionality to implement retries with client-side. This is because MongoDB guarantees us one thing: that all documents must have an `_id` field and that all documents must have unique ids by way of a unique index created automatically.

This means that all we have to do to ensure idempotent inserts is to generate the id of a document client-side if it doesn't already exist on the document.

We then watch and catch any duplicate key errors that pop up with the assumption that any that occur due to an existing id are because the previous write succeeded but was not reported back correctly.

Sadly, duplicate key errors thrown as exceptions in PHP lack any easy way to retrieve what index was violated specifically. This means we have to parse it out of the message ourselves.

It also has special handling in case a duplicate key error occurs on the very first attempt; in that case, whatever was provided violated the unique requirement of ids and shouldn't be retried. This could either mean we generated an object id that wasn't unique as it should be or that the client provided id was not unique (and thus may have special handling above the wrapper that we aren't aware of).


### Batch inserts

Batch inserts are a lot trickier to handle. Normally, they don't report back any information on successful writes other than a simple `ok`. On write concerns, you get a bit of information about the status of successful writes and any errors that popped up, but it comes with a couple of considerations.

One is that the batch operation normally throws an exception on error and stops the remaining writes from occurring. While this is fine for safety, when retrying it poses a bit of a problem: we aren't sure of how many documents have actually succeeded and which ones we can skip over attempting to insert again.

In keeping the number of network requests down to a minimum, we have to attempt the entire batch insert multiple times ignoring errors as they pop up with the `continueOnError` option. We end up losing information about successful writes as well as information about whether or not the exception is actually one we want to ignore e.g. a connection error which we'd want to retry on versus a duplicate key error on a unique index other than the id.

The good thing is that we can ensure idempotent inserts in the same way we do for singular inserts by generating the id client-side.

### Updates

Most every update can be safely retried. There's only a handful of operations that, when performed multiple times, have a chance of either over- or under-modifying (a) document(s) more than intended. Sadly, quite a few of them are also quite useful and are used very heavily in most applications. In order for update retries to be integrated fully with an application, it'll require quite a bit more changes to accommodate for the restrictions imposed by these changes.

# On Doctrine, the new Mongo driver and userland library, and the adapter package

Currently there are two things that the adapter library doesn't seem to handle from internal testing: 

1. empty `BulkWriteException`s that seem to crop up during re-elections, and;
2. the `continueOnError` option not being converted to the near-equivalent `ordered` option in the `insertMany` function.

> Please be sure to look over the commit messages as well since they offer contextual explanations.